### PR TITLE
Add fake Google sign-in Easter egg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ public/sitemap.xml
 # Personal notes
 improvements.md
 internalize.md
+fun-pranks.md

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/components/fake-sign-in.tsx
+++ b/src/components/fake-sign-in.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState } from "react";
+
+export function FakeSignIn() {
+  const [showModal, setShowModal] = useState(false);
+
+  return (
+    <>
+      <button
+        onClick={() => setShowModal(true)}
+        className="flex items-center gap-3 rounded border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50"
+      >
+        <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
+          <path
+            fill="#4285F4"
+            d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+          />
+          <path
+            fill="#34A853"
+            d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+          />
+          <path
+            fill="#FBBC05"
+            d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+          />
+          <path
+            fill="#EA4335"
+            d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+          />
+        </svg>
+        Sign in with Google
+      </button>
+
+      {showModal && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+          onClick={() => setShowModal(false)}
+        >
+          <div
+            className="mx-4 max-w-md rounded-lg bg-white p-8 text-center shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <p className="text-4xl">🤨</p>
+            <h2 className="mt-4 text-xl font-bold tracking-wider">
+              Hold on a second...
+            </h2>
+            <p className="mt-3 text-gray-600">
+              Why are you trying to sign into some random guy&apos;s portfolio
+              website?
+            </p>
+            <button
+              onClick={() => setShowModal(false)}
+              className="mt-6 border border-black px-6 py-2 text-sm uppercase tracking-wider transition-colors hover:bg-black hover:text-white"
+            >
+              Fair point
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/fake-sign-in.tsx
+++ b/src/components/fake-sign-in.tsx
@@ -8,6 +8,7 @@ export function FakeSignIn() {
   return (
     <>
       <button
+        type="button"
         onClick={() => setShowModal(true)}
         className="flex items-center gap-3 rounded border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50"
       >

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,4 +1,5 @@
 import { Github, Linkedin, Mail } from "lucide-react";
+import { FakeSignIn } from "@/components/fake-sign-in";
 
 export function Footer() {
   const name = "DEVAN MCGEER";
@@ -30,6 +31,9 @@ export function Footer() {
         <p className="text-md mt-4 tracking-[0.3em] text-gray-700 sm:text-lg sm:tracking-[0.4em] md:text-xl">
           {name}
         </p>
+      </div>
+      <div className="mt-4">
+        <FakeSignIn />
       </div>
     </footer>
   );


### PR DESCRIPTION
## Summary

- Adds a "Sign in with Google" button to the footer with a pixel-perfect Google logo
- Clicking it opens a modal: "Why are you trying to sign into some random guy's portfolio website?"
- "Fair point" button dismisses the modal
- Also adds `fun-pranks.md` to `.gitignore` for local prank idea tracking

## Test plan

- [ ] Verify button renders in footer on desktop
- [ ] Verify button renders in footer on mobile
- [ ] Click button — modal appears with message
- [ ] Click "Fair point" — modal dismisses
- [ ] Click backdrop — modal dismisses
- [ ] Verify button is NOT in the header

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive sign-in-style button in the footer that opens a full-screen modal with explanatory text, an emoji, and a dismiss action; modal closes by tapping outside or using the provided button.

* **Chores**
  * Updated project ignores to exclude a personal notes file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->