### PR TITLE
Harden CSP and add SRI for font preloads

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,10 +3,7 @@
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<meta
-			http-equiv="Content-Security-Policy"
-			content="default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://mcgeer.dev; connect-src 'self'; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'"
-		/>
+		<meta http-equiv="Content-Security-Policy" content="%VITE_CSP%" />
 		<title>Devan McGeer — Site Reliability Engineer</title>
 		<meta name="description" content="Site Reliability Engineer with 5 years of experience in Kubernetes, Terraform, Go, and AWS. Building observability pipelines, automating infrastructure, and improving CI/CD reliability for production systems." />
 		<meta property="og:title" content="Devan McGeer — Site Reliability Engineer" />

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<meta
 			http-equiv="Content-Security-Policy"
-			content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://mcgeer.dev; connect-src 'self'; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'"
+			content="default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://mcgeer.dev; connect-src 'self'; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'"
 		/>
 		<title>Devan McGeer — Site Reliability Engineer</title>
 		<meta name="description" content="Site Reliability Engineer with 5 years of experience in Kubernetes, Terraform, Go, and AWS. Building observability pipelines, automating infrastructure, and improving CI/CD reliability for production systems." />
@@ -18,18 +18,13 @@
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<link rel="preconnect" href="https://fonts.googleapis.com" />
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-		<link rel="preload" href="https://fonts.gstatic.com/s/lekton/v21/SZc43FDmLaWmWpBuWB3pv0Db6A.woff2" as="font" type="font/woff2" crossorigin />
-		<link rel="preload" href="https://fonts.gstatic.com/s/lekton/v21/SZc73FDmLaWmWpBm4zj8kmLWwjFHgA.woff2" as="font" type="font/woff2" crossorigin />
-		<link rel="preload" href="https://fonts.gstatic.com/s/lexendzetta/v32/ll8uK2KYXje7CdOFnEWcU8synQbuVYjYB3BCy9bG4zlpb-0vftqvPQ.woff2" as="font" type="font/woff2" crossorigin />
+		<link rel="preload" href="https://fonts.gstatic.com/s/lekton/v21/SZc43FDmLaWmWpBuWB3pv0Db6A.woff2" as="font" type="font/woff2" crossorigin integrity="sha384-Va3qYLQGT9BswpNgOZ6wTcqAJNl7SKNbVaT760BJ5u6Wi/AFJKIvSAvcTSTpowy6" />
+		<link rel="preload" href="https://fonts.gstatic.com/s/lekton/v21/SZc73FDmLaWmWpBm4zj8kmLWwjFHgA.woff2" as="font" type="font/woff2" crossorigin integrity="sha384-Pu5rgB+GhG617AKxmvcghkzEN+L9J1NS4H0hlZBNMtNTQSDnURoPf14U5UyQJI+7" />
+		<link rel="preload" href="https://fonts.gstatic.com/s/lexendzetta/v32/ll8uK2KYXje7CdOFnEWcU8synQbuVYjYB3BCy9bG4zlpb-0vftqvPQ.woff2" as="font" type="font/woff2" crossorigin integrity="sha384-Tr0JI6yl5TOHU03C+rBzeqGgeY3KaYYa9+foVjbxg+4aj77IL+VKESNBeBQj+sfv" />
 		<link
 			href="https://fonts.googleapis.com/css2?family=Lekton:wght@400;700&family=Lexend+Zetta&display=swap"
 			rel="stylesheet"
-			media="print"
-			onload="this.media='all'"
 		/>
-		<noscript>
-			<link href="https://fonts.googleapis.com/css2?family=Lekton:wght@400;700&family=Lexend+Zetta&display=swap" rel="stylesheet" />
-		</noscript>
 </head>
 	<body>
 		<div id="root"></div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,49 @@
-import { defineConfig } from 'vite'
+import { defineConfig, type Plugin } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 
+const cspPolicies = {
+	production: [
+		"default-src 'self'",
+		"script-src 'self'",
+		"style-src 'self' https://fonts.googleapis.com",
+		"font-src 'self' https://fonts.gstatic.com",
+		"img-src 'self' data: https://mcgeer.dev",
+		"connect-src 'self'",
+		"frame-src 'none'",
+		"object-src 'none'",
+		"base-uri 'self'",
+		"form-action 'self'",
+	],
+	development: [
+		"default-src 'self'",
+		"script-src 'self' 'unsafe-inline'",
+		"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+		"font-src 'self' https://fonts.gstatic.com",
+		"img-src 'self' data: https://mcgeer.dev",
+		"connect-src 'self' ws: wss:",
+		"frame-src 'none'",
+		"object-src 'none'",
+		"base-uri 'self'",
+		"form-action 'self'",
+	],
+}
+
+function cspPlugin(): Plugin {
+	return {
+		name: 'csp-policy',
+		transformIndexHtml: {
+			order: 'pre',
+			handler(_html, ctx) {
+				const env = ctx.server ? 'development' : 'production'
+				return _html.replace('%VITE_CSP%', cspPolicies[env].join('; '))
+			},
+		},
+	}
+}
+
 export default defineConfig({
-	plugins: [react()],
+	plugins: [react(), cspPlugin()],
 	resolve: {
 		alias: {
 			'@': path.resolve(__dirname, './src'),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,5 +11,6 @@ export default defineConfig({
 	},
 	build: {
 		outDir: 'dist',
+		modulePreload: { polyfill: false },
 	},
 })


### PR DESCRIPTION
## Summary

- Remove `'unsafe-inline'` from `script-src` and `style-src` CSP directives
- Eliminate inline `onload` event handler on Google Fonts stylesheet link
- Disable Vite modulepreload polyfill (injected inline script in prod builds)
- Add SHA-384 `integrity` attributes to all 3 font preload `<link>` tags

Resolves 3 of 5 medium-severity findings from a ZAP security scan:
1. **CSP: script-src unsafe-inline** — no inline scripts remain in production output
2. **CSP: style-src unsafe-inline** — no inline styles used in codebase
3. **Sub Resource Integrity Attribute Missing** — SRI hashes added to font preloads

### Not fixable from code (GitHub Pages limitations)
- Cross-Domain Misconfiguration (`Access-Control-Allow-Origin: *` set server-side)
- Missing Anti-clickjacking (`frame-ancestors` not supported in `<meta>` CSP)
- COEP/COOP/Permissions-Policy/X-Content-Type-Options (require HTTP response headers)

## Test plan

- [ ] Verify `pnpm build` succeeds with no inline scripts in `dist/index.html`
- [ ] Verify fonts load correctly on the deployed site
- [ ] Confirm no browser console CSP violation errors
- [ ] Re-run ZAP scan to confirm resolved findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Content-Security-Policy management with build-time configuration.
  * Optimized font loading with integrity verification for improved security.
  * Improved build process configuration for streamlined production deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->