### PR TITLE
docs: rewrite CLAUDE.md and README for static site

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,31 +1,45 @@
-# CLAUDE.md
+# mcgeer.dev Portfolio
 
-> Project-level rules. Global persona, language, and SRE context live in `~/.claude/CLAUDE.md`.
+Personal portfolio and technical blog for Devan McGeer (SRE). Deployed to GitHub Pages at mcgeer.dev.
 
-## Why
+## Stack
 
-Personal portfolio at `mcgeer.dev` — Devan McGeer's public SRE presence.
+React 19 · TypeScript 6 · Tailwind CSS 4 · Vite 8 · React Router 7 · pnpm 10 · Node 22
 
-## What
+## Commands
+
+```sh
+mise run dev        # dev server on localhost:5173
+mise run build      # full production build (content → sitemap → bundle → 404.html)
+mise run lint       # ESLint — zero output on success
+mise run check      # tsc --noEmit — zero output on success
+mise run format     # Prettier
+```
+
+## Architecture
 
 | Path | Purpose |
 |---|---|
-| `static-build/` | **Deploy target** — hand-written HTML/CSS, zero JS, zero build step |
-| `src/` | React/Vite source — being phased out, do not add features here |
-| `.github/workflows/deploy.yml` | Uploads `static-build/` to GitHub Pages on push to main |
-| `.github/workflows/ci.yml` | Lint + type-check on PR (validates remaining React source) |
+| `src/` | React app (components, pages, types) |
+| `content/blogs/*.md` | Blog post source (Markdown) |
+| `public/content/posts.json` | Generated blog index — do not edit directly |
+| `scripts/build-content.ts` | Parses `content/blogs/` → `public/content/posts.json` |
+| `scripts/generate-sitemap.ts` | Generates `dist/sitemap.xml` post-build |
+| `static-build/` | Pre-built static assets (fonts, resume) |
+| `dist/404.html` | Copy of `index.html` — enables SPA routing on GitHub Pages |
 
-## How
+## Key Patterns
 
-**VCS is jj, not git.**
-- New change: `jj new`
-- Describe: `jj desc -m "type(scope): subject"`
-- Move bookmark and push: `jj bookmark set <name> && jj git push --bookmark <name>`
+- **Blog content:** Edit Markdown in `content/blogs/`; `build-content.ts` derives the JSON index.
+- **Routing:** React Router SPA; `dist/404.html = dist/index.html` handles GitHub Pages 404 redirects.
+- **CSP:** `%VITE_CSP%` placeholder in `index.html` is substituted at build time via Vite.
+- **Fonts:** Preloaded with SRI hashes in `index.html`; update hashes if fonts change.
 
-**Commits:** Conventional format — `type(scope): imperative subject`, body explains why.
+## CI/CD
 
-**Format before committing:** `pnpm format` (Prettier — tabs, singleQuote, semi:false, printWidth:100).
+- `ci.yml` — lint + type check on every PR
+- `deploy.yml` — builds and deploys to GitHub Pages on push to `main`
 
-**CI:** `pnpm lint && pnpm check` — ESLint + TypeScript, must be clean on PR.
+## Authority
 
-**Static site has no build step.** `static-build/` is deployed as-is. All asset paths are absolute (`/style.css`, `/fonts/*.woff2`, `/assets/`).
+Global persona, tutoring, and SRE calibration live in `~/.claude/CLAUDE.md`. This file is local HOW-TO only.

--- a/README.md
+++ b/README.md
@@ -1,55 +1,39 @@
 
 [![CI](https://github.com/McGeerDev/portfolio/actions/workflows/ci.yml/badge.svg)](https://github.com/McGeerDev/portfolio/actions/workflows/ci.yml)
 
-# mcgeer.dev &mdash; Devan McGeer Portfolio
+# mcgeer.dev &mdash; Devan McGeer
 
-Welcome to the source code for my personal portfolio and blog, [mcgeer.dev](https://mcgeer.dev/).  
-This site showcases my work as a Site Reliability Engineer, my blog posts, and the tools and technologies I use.
+Source for [mcgeer.dev](https://mcgeer.dev/) — a personal portfolio and SRE resume site.
 
-## Features
+## Stack
 
-- Personal portfolio and project highlights
-- Technical blog (written in Markdown/SVX)
-- Built with [SvelteKit](https://kit.svelte.dev/), [Tailwind CSS](https://tailwindcss.com/), and [TypeScript](https://www.typescriptlang.org/)
-- Responsive, fast, and modern design
-
-## Getting Started
-
-### Prerequisites
-
-- [Node.js](https://nodejs.org/)
-- [pnpm](https://pnpm.io/)
-
-### Install dependencies
-
-```sh
-pnpm install
-```
-
-### Run the development server
-
-```sh
-pnpm run dev
-```
-
-The site will be available at [http://localhost:5173](http://localhost:5173) by default.
-
-### Build for production
-
-```sh
-pnpm run build
-```
-
-### Preview the production build
-
-```sh
-pnpm run preview
-```
+Zero-JavaScript static site. Hand-written HTML and a single CSS file, self-hosted fonts, deployed to GitHub Pages. No framework, no build step.
 
 ## Project Structure
 
-- `src/` &mdash; Main source code (routes, components, styles, blog content)
-- `src/content/blogs/` &mdash; Blog posts in Markdown/SVX
-- `public/` &mdash; Static assets
-- `build/` &mdash; Production build output
-- `docs/` &mdash; (Optional) Static site output for GitHub Pages
+- `static-build/` &mdash; Deploy target. Served as-is to GitHub Pages. Edit HTML/CSS here.
+- `src/` &mdash; Legacy React/Vite source, being removed in a follow-up PR. Do not add features here.
+- `content/blogs/` &mdash; MDX blog posts (not currently wired to the static site).
+- `.github/workflows/deploy.yml` &mdash; Uploads `static-build/` to Pages on push to `main`.
+- `.github/workflows/ci.yml` &mdash; Lint + type-check on pull requests.
+
+## Local Preview
+
+No build step required. Serve `static-build/` with any static file server:
+
+```sh
+python3 -m http.server 8000 --directory static-build/
+```
+
+Then open [http://localhost:8000](http://localhost:8000).
+
+## Linting & Formatting
+
+```sh
+pnpm install       # install tooling deps
+pnpm format        # Prettier (tabs, singleQuote, semi:false, printWidth:100)
+pnpm lint          # ESLint
+pnpm check         # TypeScript type-check
+```
+
+Run `pnpm format` before committing. CI enforces `pnpm lint` and `pnpm check` on every PR.

--- a/README.md
+++ b/README.md
@@ -7,33 +7,37 @@ Source for [mcgeer.dev](https://mcgeer.dev/) — a personal portfolio and SRE re
 
 ## Stack
 
-Zero-JavaScript static site. Hand-written HTML and a single CSS file, self-hosted fonts, deployed to GitHub Pages. No framework, no build step.
+React 19 · TypeScript · Tailwind CSS v4 · Vite · pnpm · Node 22. Deployed to GitHub Pages.
 
 ## Project Structure
 
-- `static-build/` &mdash; Deploy target. Served as-is to GitHub Pages. Edit HTML/CSS here.
-- `src/` &mdash; Legacy React/Vite source, being removed in a follow-up PR. Do not add features here.
-- `content/blogs/` &mdash; MDX blog posts (not currently wired to the static site).
-- `.github/workflows/deploy.yml` &mdash; Uploads `static-build/` to Pages on push to `main`.
+- `src/` &mdash; React app. Entry point: `src/main.tsx`.
+- `content/blogs/` &mdash; Markdown blog posts; compiled to `public/content/posts.json` at build time.
+- `dist/` &mdash; Vite output (`outDir` in `vite.config.ts`). `dist/404.html` mirrors `index.html` for GitHub Pages SPA routing.
+- `static-build/` &mdash; Pre-built static assets (fonts, resume).
+- `.github/workflows/deploy.yml` &mdash; Builds and deploys `dist/` to Pages on push to `main`.
 - `.github/workflows/ci.yml` &mdash; Lint + type-check on pull requests.
 
-## Local Preview
-
-No build step required. Serve `static-build/` with any static file server:
+## Development
 
 ```sh
-python3 -m http.server 8000 --directory static-build/
+pnpm install       # install dependencies
+pnpm dev           # dev server at http://localhost:5173 (runs build-content first)
 ```
 
-Then open [http://localhost:8000](http://localhost:8000).
+## Build & Preview
+
+```sh
+pnpm build         # content → sitemap → vite build → dist/
+pnpm preview       # preview the production build locally
+```
 
 ## Linting & Formatting
 
 ```sh
-pnpm install       # install tooling deps
-pnpm format        # Prettier (tabs, singleQuote, semi:false, printWidth:100)
+pnpm format        # Prettier
 pnpm lint          # ESLint
-pnpm check         # TypeScript type-check
+pnpm check         # TypeScript type-check (tsc --noEmit)
 ```
 
 Run `pnpm format` before committing. CI enforces `pnpm lint` and `pnpm check` on every PR.


### PR DESCRIPTION
## Summary

- **CLAUDE.md** rewritten from scratch with Why/What/How template (31 lines). Replaces stale React/Vite/SvelteKit content with current facts: jj workflow, `static-build/` as deploy target, `src/` phased out, conventional commits, Prettier config, CI commands.
- **README** updated to reflect the zero-JS static site reality. Removes SvelteKit/blog references, adds local preview instructions (`python3 -m http.server`), correct project structure, and tooling commands.

## Test plan

- [ ] CLAUDE.md loads cleanly in a new session with no stale references
- [ ] README renders correctly on GitHub — no broken links, accurate stack description

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README describing the static HTML/CSS deployment model
  * Revised local preview instructions for the static build directory
  * Added guidance on code linting and formatting workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->