### PR TITLE
Add Vary: Accept-Encoding to compressible assets

### DIFF
--- a/_headers
+++ b/_headers
@@ -12,12 +12,16 @@
 
 /favicon.svg
   Cache-Control: public, max-age=2592000
+  Vary: Accept-Encoding
 
 /style.css
   Cache-Control: public, max-age=86400
+  Vary: Accept-Encoding
 
 /*.html
   Cache-Control: public, max-age=600, must-revalidate
+  Vary: Accept-Encoding
 
 /
   Cache-Control: public, max-age=600, must-revalidate
+  Vary: Accept-Encoding


### PR DESCRIPTION
## Summary

- Adds `Vary: Accept-Encoding` to HTML, CSS, and SVG entries in `_headers`
- Without it a CDN can collapse gzip and identity responses into a single cache slot, or serve an encoded body to a client that only asked for identity
- No functional change on the current GitHub Pages host — this is forward-looking for the Cloudflare Pages migration

## Test plan

- [ ] CI passes (html5validator, lychee)
- [ ] Verify `Vary: Accept-Encoding` appears in response headers after deploy: `curl -sI https://mcgeer.dev/ | grep -i vary`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced caching configuration to optimize content delivery for static assets, stylesheets, HTML pages, and the site root, improving performance when serving compressed content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->