### PR TITLE
Extend style.css TTL and fix HTML glob in _headers

### DIFF
--- a/_headers
+++ b/_headers
@@ -15,10 +15,10 @@
   Vary: Accept-Encoding
 
 /style.css
-  Cache-Control: public, max-age=86400
+  Cache-Control: public, max-age=2592000
   Vary: Accept-Encoding
 
-/*.html
+/**/*.html
   Cache-Control: public, max-age=600, must-revalidate
   Vary: Accept-Encoding
 


### PR DESCRIPTION
## Summary

- Align `style.css` cache TTL with other static assets: `max-age=86400` → `max-age=2592000` (1 day → 30 days). CSS changes infrequently; no reason for a shorter TTL than fonts/images.
- Fix HTML glob: `/*.html` → `/**/*.html` so `/resume/index.html` and any future subdirectory pages get the same short-TTL, must-revalidate policy.

Addresses the YSlow rule: all static page components (scripts, styles, images) should carry long-lived `Cache-Control` headers to avoid unnecessary HTTP requests on repeat visits.

> Note: `immutable` is still deferred until filenames are content-hashed.

## Test plan

- [ ] Verify `_headers` parses correctly on a Cloudflare Pages preview deploy
- [ ] Check `/style.css` response headers show `max-age=2592000`
- [ ] Check `/resume/` response headers show `max-age=600, must-revalidate`
- [ ] HTML validator CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)