### PR TITLE
Compute home-page experience duration via JS

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
         if: github.event_name != 'schedule' || steps.check.outputs.has_commits == 'true'
         run: |
           mkdir _site
-          cp -r index.html 404.html style.css favicon.svg og-image.png \
+          cp -r index.html 404.html style.css experience-counter.js favicon.svg og-image.png \
                 robots.txt sitemap.xml CNAME _headers \
                 fonts assets resume \
                 _site/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Personal portfolio and résumé site for Devan McGeer (SRE). Deployed to GitHub 
 
 ## Stack
 
-Hand-written HTML + CSS · no JS · no build step · GitHub Pages
+Hand-written HTML + CSS · minimal JS (one progressive-enhancement script) · no build step · GitHub Pages
 
 ## Layout
 
@@ -20,6 +20,7 @@ Hand-written HTML + CSS · no JS · no build step · GitHub Pages
 | `robots.txt`, `sitemap.xml` | Crawler hints |
 | `CNAME` | Pins custom domain `mcgeer.dev` |
 | `_headers` | Cache-Control rules for Cloudflare Pages migration (no-op on GitHub Pages) |
+| `experience-counter.js` | Live home-page experience counter (years + months from Dec 2020) |
 | `.impeccable.md` | Design context — brand, users, principles |
 
 ## Local preview
@@ -41,7 +42,7 @@ python3 -m http.server 8000
 - **Fonts:** Self-hosted woff2 in `/fonts/`, preloaded with `crossorigin` from `index.html`. No CDN, no SRI needed.
 - **CSP:** Hard-coded in each HTML file's `<meta http-equiv="Content-Security-Policy">` tag. No build-time substitution.
 - **Custom domain:** `CNAME` pins `mcgeer.dev`. DNS is proxied through Cloudflare (`Server: cloudflare` on every response); the GitHub Pages backend is the origin.
-- **Cache headers:** GitHub Pages serves all assets with `Cache-Control: max-age=600` and ignores any per-file config. The `_headers` file is dormant on the current host but ready for a Cloudflare Pages migration, where it sets per-path TTLs. Do not add `immutable` until filename hashing lands.
+- **Cache headers:** GitHub Pages serves all assets with `Cache-Control: max-age=600` and ignores any per-file config. The `_headers` file is dormant on the current host but ready for a Cloudflare Pages migration, where it sets per-path TTLs for `style.css`, `experience-counter.js`, fonts, and assets. Do not add `immutable` until filename hashing lands.
 - **Canonical URLs:** Indexable pages carry `<link rel="canonical">` pointing to the `https://mcgeer.dev/...` form with trailing slash. `404.html` deliberately omits canonical per Google's guidance for intentional 404 pages. Internal `<a href>` always uses the canonical trailing-slash form so in-site clicks never hit a redirect.
 - **Redirects (unavoidable):** Three redirects cannot be removed in repo code. (1) `http://*` → `https://*` is a security baseline. (2) `https://www.mcgeer.dev/*` → `https://mcgeer.dev/*` is canonical-host enforcement, configured in Cloudflare. (3) `https://mcgeer.dev/<dir>` → `https://mcgeer.dev/<dir>/` is GitHub Pages directory canonicalization. The only redundant chain is `http://www.mcgeer.dev/*` (HTTP+www → HTTPS+www → apex, two hops); collapsing it requires a Cloudflare Page Rule, not a repo change.
 - **Design decisions:** Consult `.impeccable.md` before changing visuals — brand, users, and design principles live there.

--- a/_headers
+++ b/_headers
@@ -18,6 +18,10 @@
   Cache-Control: public, max-age=2592000
   Vary: Accept-Encoding
 
+/experience-counter.js
+  Cache-Control: public, max-age=2592000
+  Vary: Accept-Encoding
+
 /**/*.html
   Cache-Control: public, max-age=0, must-revalidate
   Vary: Accept-Encoding

--- a/experience-counter.js
+++ b/experience-counter.js
@@ -1,0 +1,14 @@
+(function () {
+  var el = document.getElementById('experience-duration');
+  if (!el) return;
+  var start = new Date(2020, 11, 1); // Dec 2020 (0-indexed month)
+  var now = new Date();
+  var months = (now.getFullYear() - start.getFullYear()) * 12
+             + (now.getMonth() - start.getMonth());
+  if (months < 0) months = 0;
+  var years = Math.floor(months / 12);
+  var rem   = months % 12;
+  var parts = [years + ' year' + (years === 1 ? '' : 's')];
+  if (rem > 0) parts.push(rem + ' month' + (rem === 1 ? '' : 's'));
+  el.textContent = parts.join(' and ');
+})();

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
   <link rel="preload" href="/fonts/lekton-700.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="preload" href="/fonts/lexend-zetta-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/style.css">
+  <script src="/experience-counter.js" defer></script>
 </head>
 <body>
   <a href="#main" class="skip-link">Skip to content</a>
@@ -75,7 +76,7 @@
                 class="headshot"
                 loading="lazy"
               >
-              <p class="about-bio">Site Reliability Engineer with 5 years of experience in platform engineering, infrastructure automation, and full-stack development. I build and operate production Kubernetes clusters, define SLOs and SLIs, and design observability pipelines with Datadog and OpenTelemetry. Day-to-day I write Go and Terraform to automate infrastructure provisioning, improve CI/CD reliability, and reduce operational toil. Currently owning infrastructure reliability at DIDx on AWS.</p>
+              <p class="about-bio">Site Reliability Engineer with <span id="experience-duration">5 years</span> of experience in platform engineering, infrastructure automation, and full-stack development. I build and operate production Kubernetes clusters, define SLOs and SLIs, and design observability pipelines with Datadog and OpenTelemetry. Day-to-day I write Go and Terraform to automate infrastructure provisioning, improve CI/CD reliability, and reduce operational toil. Currently owning infrastructure reliability at DIDx on AWS.</p>
               <p class="about-avail">Available for remote work globally</p>
             </div>
 


### PR DESCRIPTION
## Summary

- Replaces the hard-coded `"5 years"` in the about bio with a `<span id="experience-duration">` filled at page load by a small IIFE (`experience-counter.js`)
- Duration is anchored to December 2020 (first professional role); renders as `"X years and Y months"`, dropping the months clause when `Y === 0`
- Progressive enhancement: static fallback `"5 years"` is preserved in HTML for non-JS readers and the meta description

## Notes

- CSP `script-src 'self'` is satisfied — script is same-origin, not inline
- `_headers` gains a 30-day cache rule for `/experience-counter.js` (dormant on GitHub Pages, active under Cloudflare Pages)
- `CLAUDE.md` stack description updated: site is no longer strictly no-JS

## Test Plan

- [ ] Local preview: `python3 -m http.server 8000` → bio renders `"5 years and 5 months of experience"`
- [ ] DevTools console is clean (no CSP errors, no 404 on the script)
- [ ] Disable JS → static `"5 years"` fallback renders correctly
- [ ] `html5validator` and `lychee` CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dynamic experience counter to the homepage that automatically calculates and displays professional experience duration from December 2020 to the current date, formatted in years and months.

* **Chores**
  * Updated cache configuration for new assets to optimize performance and page load times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->