### PR TITLE
Add mise static-site guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db
         with:
@@ -24,12 +24,12 @@ jobs:
         run: mise run check
 
       - name: Validate HTML
-        uses: Cyb3r-Jak3/html5validator-action@v7.2.0
+        uses: Cyb3r-Jak3/html5validator-action@41633d488eb36e18fd1a95ffc83daf1bf22a75bd
         with:
           root: .
 
       - name: Check links
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411
         with:
           args: >-
             --no-progress

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: jdx/mise-action@v3
+      - uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db
         with:
           install: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: jdx/mise-action@v3
+        with:
+          install: false
+
+      - name: Run site guardrails
+        run: mise run check
+
       - name: Validate HTML
         uses: Cyb3r-Jak3/html5validator-action@v7.2.0
         with:
@@ -26,12 +33,10 @@ jobs:
         with:
           args: >-
             --no-progress
-            --base https://mcgeer.dev
+            --root-dir ${{ github.workspace }}/_site
+            --remap '^https://mcgeer\.dev file://${{ github.workspace }}/_site'
             --exclude 'linkedin\.com'
             --exclude 'ninety10\.co\.za'
-            --exclude 'mcgeer\.dev/style\.css'
-            --exclude 'mcgeer\.dev/favicon\.svg'
-            --exclude 'mcgeer\.dev/fonts/'
             --accept 200,418,999
-            '*.html' 'resume/*.html'
+            '_site/**/*.html'
           fail: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: jdx/mise-action@v3
+        with:
+          install: false
+
       - name: Check for recent commits (scheduled runs only)
         id: check
         if: github.event_name == 'schedule'
@@ -38,72 +42,9 @@ jobs:
             echo "has_commits=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: Stage site
+      - name: Build staged site
         if: github.event_name != 'schedule' || steps.check.outputs.has_commits == 'true'
-        run: |
-          mkdir _site
-          cp -r index.html 404.html style.css favicon.svg og-image.png \
-                robots.txt sitemap.xml CNAME _headers \
-                fonts assets resume \
-                _site/
-
-      - name: Minify staged site
-        if: github.event_name != 'schedule' || steps.check.outputs.has_commits == 'true'
-        env:
-          MINIFY_VERSION: "2.24.13"
-          MINIFY_SHA256: "6cdd5c8c1d605d60f48a2f4a654595235f1fb50f804b107f72f6a6c87240a1bd"
-        run: |
-          set -euo pipefail
-          curl -fsSL -o minify.tar.gz \
-            "https://github.com/tdewolff/minify/releases/download/v${MINIFY_VERSION}/minify_linux_amd64.tar.gz"
-          echo "${MINIFY_SHA256}  minify.tar.gz" | sha256sum -c -
-          tar -xzf minify.tar.gz minify
-          chmod +x minify
-          ./minify --recursive --match='\.(html|css|svg|xml)$' --output _site/ _site/
-          rm -f minify minify.tar.gz
-
-      - name: Hash static assets
-        if: github.event_name != 'schedule' || steps.check.outputs.has_commits == 'true'
-        run: |
-          set -euo pipefail
-
-          # 1. Hash fonts and update references in style.css and HTML preloads
-          CSS=_site/style.css
-          HTMLS=(_site/index.html _site/404.html _site/resume/index.html)
-          for font in _site/fonts/*.woff2; do
-            hash=$(md5sum "$font" | cut -c1-8)
-            base=$(basename "$font" .woff2)
-            new="${base}.${hash}.woff2"
-            mv "$font" "_site/fonts/${new}"
-            sed -i "s|/fonts/${base}\.woff2|/fonts/${new}|g" "$CSS" "${HTMLS[@]}"
-          done
-
-          # 2. Hash style.css (after font refs updated) and update HTML
-          css_hash=$(md5sum "$CSS" | cut -c1-8)
-          mv "$CSS" "_site/style.${css_hash}.css"
-          sed -i "s|/style\.css|/style.${css_hash}.css|g" "${HTMLS[@]}"
-
-          # 3. Hash og-image.png and update HTML og:image references
-          og_hash=$(md5sum _site/og-image.png | cut -c1-8)
-          mv _site/og-image.png "_site/og-image.${og_hash}.png"
-          sed -i "s|/og-image\.png|/og-image.${og_hash}.png|g" _site/index.html _site/resume/index.html
-
-          # 4. Hash favicon.svg and update HTML references
-          fav_hash=$(md5sum _site/favicon.svg | cut -c1-8)
-          mv _site/favicon.svg "_site/favicon.${fav_hash}.svg"
-          sed -i "s|/favicon\.svg|/favicon.${fav_hash}.svg|g" "${HTMLS[@]}"
-
-          # 5. Append immutable rules to _headers for each hashed asset
-          {
-            printf '\n# Hashed assets — immutable caching (appended at deploy time)\n'
-            for font in _site/fonts/*.woff2; do
-              n=$(basename "$font")
-              printf '\n/fonts/%s\n  Cache-Control: public, max-age=31536000, immutable\n' "$n"
-            done
-            printf '\n/style.%s.css\n  Cache-Control: public, max-age=31536000, immutable\n  Vary: Accept-Encoding\n' "$css_hash"
-            printf '\n/og-image.%s.png\n  Cache-Control: public, max-age=31536000, immutable\n  Vary: Accept-Encoding\n' "$og_hash"
-            printf '\n/favicon.%s.svg\n  Cache-Control: public, max-age=31536000, immutable\n  Vary: Accept-Encoding\n' "$fav_hash"
-          } >> _site/_headers
+        run: mise run build:minified
 
       - uses: actions/upload-pages-artifact@v3
         if: github.event_name != 'schedule' || steps.check.outputs.has_commits == 'true'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,11 +22,11 @@ jobs:
     outputs:
       has_commits: ${{ steps.check.outputs.has_commits }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 
-      - uses: jdx/mise-action@9dc7d5dd454262207dea3ab5a06a3df6afc8ff26
+      - uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db
         with:
           install: false
 
@@ -46,7 +46,7 @@ jobs:
         if: github.event_name != 'schedule' || steps.check.outputs.has_commits == 'true'
         run: mise run build:minified
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa
         if: github.event_name != 'schedule' || steps.check.outputs.has_commits == 'true'
         with:
           path: _site
@@ -60,4 +60,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: jdx/mise-action@v3
+      - uses: jdx/mise-action@9dc7d5dd454262207dea3ab5a06a3df6afc8ff26
         with:
           install: false
 

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,15 @@
+[tasks.serve]
+description = "Serve the static site locally"
+run = "python3 -m http.server 8000"
+
+[tasks.build]
+description = "Stage the public site into _site"
+run = "scripts/build-site.sh"
+
+[tasks."build:minified"]
+description = "Stage, minify, and hash the public site into _site"
+run = "scripts/build-site.sh --minify"
+
+[tasks.check]
+description = "Run static-site guardrails"
+run = "scripts/check-site.sh"

--- a/404.html
+++ b/404.html
@@ -28,7 +28,7 @@
           <a href="/" class="nav-logo">DM</a>
           <div class="nav-links">
             <a href="/" class="nav-link">HOME</a>
-            <a href="/#selected-work" class="nav-link">PROJECTS</a>
+            <a href="/projects/" class="nav-link">PROJECTS</a>
             <a href="/resume/" class="nav-link">RESUME</a>
             <a href="/blog/" class="nav-link">BLOG</a>
           </div>
@@ -43,7 +43,7 @@
             </summary>
             <nav class="nav-mobile-menu" aria-label="Main navigation">
               <a href="/" class="nav-mobile-link">HOME</a>
-              <a href="/#selected-work" class="nav-mobile-link">PROJECTS</a>
+              <a href="/projects/" class="nav-mobile-link">PROJECTS</a>
               <a href="/resume/" class="nav-mobile-link">RESUME</a>
               <a href="/blog/" class="nav-mobile-link">BLOG</a>
             </nav>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Personal portfolio and résumé site for Devan McGeer (SRE). Deployed to GitHub 
 
 ## Stack
 
-Hand-written HTML + CSS · minimal JS (one progressive-enhancement script) · no build step · GitHub Pages
+Hand-written HTML + CSS · zero JavaScript by default · no framework · `mise` task runner · GitHub Pages
 
 ## Layout
 
@@ -14,36 +14,54 @@ Hand-written HTML + CSS · minimal JS (one progressive-enhancement script) · no
 | `404.html` | GitHub Pages 404 fallback (standalone page, not SPA) |
 | `style.css` | All styles, single file |
 | `resume/index.html` | `/resume/` page |
+| `projects/index.html` | `/projects/` page |
+| `blog/index.html` | `/blog/` landing page |
+| `blog/*/index.html` | Draft posts; not published unless added to `sitemap.xml` |
 | `fonts/` | Self-hosted woff2 (lekton-400, lekton-700, lexend-zetta-400) |
 | `assets/` | `devan-mcgeer-cv.pdf`, `headshot.webp` |
 | `favicon.svg`, `og-image.png` | Site icons + social card |
 | `robots.txt`, `sitemap.xml` | Crawler hints |
 | `CNAME` | Pins custom domain `mcgeer.dev` |
 | `_headers` | Cache-Control rules for Cloudflare Pages migration (no-op on GitHub Pages) |
-| `experience-counter.js` | Live home-page experience counter (years + months from Dec 2020) |
+| `.mise.toml` | Local task interface for agents, CI, and deploy |
+| `scripts/build-site.sh` | Stages sitemap-listed public pages into `_site/`, then hashes assets |
+| `scripts/check-site.sh` | Static-site guardrails for public output |
 | `.impeccable.md` | Design context — brand, users, principles |
 
 ## Local preview
 
 ```sh
-python3 -m http.server 8000
+mise run serve
 # open http://localhost:8000/
+```
+
+## Local tasks
+
+```sh
+mise run check
+mise run build
+mise run build:minified
+mise run serve
 ```
 
 ## CI/CD
 
-- `ci.yml` — `html5validator` + `lychee` link check on every PR
-- `deploy.yml` — stages site files into `_site/` and publishes to GitHub Pages on push to `main`; daily cron rebuild gated on whether there were commits in the last 24h
+- `ci.yml` — runs `mise run check`, validates HTML, and checks links on every PR
+- `deploy.yml` — runs `mise run build:minified`, uploads `_site/`, and publishes to GitHub Pages on push to `main`; daily cron rebuild gated on whether there were commits in the last 24h
 
 ## Key Patterns
 
 - **Single CSS file:** `style.css`. No preprocessor, no framework.
+- **Smallest static site:** keep runtime JavaScript at zero unless a change has an explicit progressive-enhancement justification. Do not add `package.json`, bundlers, client frameworks, or external runtime CDNs.
+- **Public surface:** pages listed in `sitemap.xml` are published by `scripts/build-site.sh`. Draft files may exist in the repo, but they are not public unless they are added to `sitemap.xml`.
 - **404 handling:** `404.html` is a real standalone page. GitHub Pages serves it on unmatched paths — not a SPA fallback.
 - **Fonts:** Self-hosted woff2 in `/fonts/`, preloaded with `crossorigin` from `index.html`. No CDN, no SRI needed.
 - **CSP:** Hard-coded in each HTML file's `<meta http-equiv="Content-Security-Policy">` tag. No build-time substitution.
 - **Custom domain:** `CNAME` pins `mcgeer.dev`. DNS is proxied through Cloudflare (`Server: cloudflare` on every response); the GitHub Pages backend is the origin.
-- **Cache headers:** GitHub Pages serves all assets with `Cache-Control: max-age=600` and ignores any per-file config. The `_headers` file is dormant on the current host but ready for a Cloudflare Pages migration, where it sets per-path TTLs for `style.css`, `experience-counter.js`, fonts, and assets. Do not add `immutable` until filename hashing lands.
+- **Cache headers:** GitHub Pages serves all assets with `Cache-Control: max-age=600` and ignores any per-file config. The `_headers` file is dormant on the current host but ready for a Cloudflare Pages migration. `scripts/build-site.sh` appends immutable rules for hashed CSS, font, favicon, and social-card assets.
 - **Canonical URLs:** Indexable pages carry `<link rel="canonical">` pointing to the `https://mcgeer.dev/...` form with trailing slash. `404.html` deliberately omits canonical per Google's guidance for intentional 404 pages. Internal `<a href>` always uses the canonical trailing-slash form so in-site clicks never hit a redirect.
+- **Project links:** Internal navigation points to `/projects/`, not `/#selected-work`.
+- **Guardrails:** `mise run check` must pass before handoff. It rejects public TODO placeholders, unexpected JavaScript/package-manager files in `_site/`, missing sitemap pages, and sitemap/canonical drift.
 - **Redirects (unavoidable):** Three redirects cannot be removed in repo code. (1) `http://*` → `https://*` is a security baseline. (2) `https://www.mcgeer.dev/*` → `https://mcgeer.dev/*` is canonical-host enforcement, configured in Cloudflare. (3) `https://mcgeer.dev/<dir>` → `https://mcgeer.dev/<dir>/` is GitHub Pages directory canonicalization. The only redundant chain is `http://www.mcgeer.dev/*` (HTTP+www → HTTPS+www → apex, two hops); collapsing it requires a Cloudflare Page Rule, not a repo change.
 - **Design decisions:** Consult `.impeccable.md` before changing visuals — brand, users, and design principles live there.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Source for [mcgeer.dev](https://mcgeer.dev/) &mdash; personal portfolio and SRE 
 
 ## Stack
 
-Hand-written HTML + CSS. No JavaScript, no build step, no dependencies. Deployed to GitHub Pages.
+Hand-written HTML + CSS. Zero JavaScript by default, no framework, no package manifest. `mise` provides the local task interface. Deployed to GitHub Pages.
 
 ## Project Structure
 
@@ -14,26 +14,46 @@ Hand-written HTML + CSS. No JavaScript, no build step, no dependencies. Deployed
 - `404.html` &mdash; GitHub Pages 404 fallback
 - `style.css` &mdash; all styles, single file
 - `resume/index.html` &mdash; `/resume/` page
+- `projects/index.html` &mdash; `/projects/` page
+- `blog/index.html` &mdash; `/blog/` landing page
 - `favicon.svg`, `og-image.png` &mdash; site icons and social card
 - `robots.txt`, `sitemap.xml` &mdash; crawler directives
 - `CNAME` &mdash; custom domain (`mcgeer.dev`)
 - `fonts/` &mdash; self-hosted `woff2` (Lekton 400/700, Lexend Zetta 400)
 - `assets/` &mdash; résumé PDF and headshot
 - `.impeccable.md` &mdash; brand, users, and design principles
+- `.mise.toml` &mdash; local task definitions
+- `scripts/` &mdash; build and guardrail scripts
 - `.github/workflows/` &mdash; `ci.yml` and `deploy.yml`
 
 ## Local preview
 
 ```sh
-python3 -m http.server 8000
+mise run serve
 ```
 
 Then open <http://localhost:8000/>.
 
+## Local tasks
+
+```sh
+mise run check
+mise run build
+mise run build:minified
+mise run serve
+```
+
 ## CI/CD
 
-- `ci.yml` &mdash; validates HTML and checks links on pull requests.
-- `deploy.yml` &mdash; publishes to GitHub Pages on push to `main`, with a daily cron rebuild gated on recent commits.
+- `ci.yml` &mdash; runs site guardrails, validates HTML, and checks links on pull requests.
+- `deploy.yml` &mdash; stages the sitemap-listed public surface into `_site/`, minifies and hashes static assets, then publishes to GitHub Pages on push to `main`.
+
+## Static-site rules
+
+- Keep runtime JavaScript at zero unless a change has a specific progressive-enhancement reason.
+- Keep CSS in `style.css`; do not add a frontend framework or bundler.
+- Pages listed in `sitemap.xml` are the published surface. Draft files are not public unless added there.
+- Run `mise run check` before handing off changes.
 
 ## License
 

--- a/blog/index.html
+++ b/blog/index.html
@@ -36,7 +36,7 @@
           <a href="/" class="nav-logo">DM</a>
           <div class="nav-links">
             <a href="/" class="nav-link">HOME</a>
-            <a href="/#selected-work" class="nav-link">PROJECTS</a>
+            <a href="/projects/" class="nav-link">PROJECTS</a>
             <a href="/resume/" class="nav-link">RESUME</a>
             <a href="/blog/" class="nav-link active">BLOG</a>
           </div>
@@ -51,7 +51,7 @@
             </summary>
             <nav class="nav-mobile-menu" aria-label="Main navigation">
               <a href="/" class="nav-mobile-link">HOME</a>
-              <a href="/#selected-work" class="nav-mobile-link">PROJECTS</a>
+              <a href="/projects/" class="nav-mobile-link">PROJECTS</a>
               <a href="/resume/" class="nav-mobile-link">RESUME</a>
               <a href="/blog/" class="nav-mobile-link active">BLOG</a>
             </nav>

--- a/blog/zpd-harness-claude/index.html
+++ b/blog/zpd-harness-claude/index.html
@@ -36,7 +36,7 @@
           <a href="/" class="nav-logo">DM</a>
           <div class="nav-links">
             <a href="/" class="nav-link">HOME</a>
-            <a href="/#selected-work" class="nav-link">PROJECTS</a>
+            <a href="/projects/" class="nav-link">PROJECTS</a>
             <a href="/resume/" class="nav-link">RESUME</a>
             <a href="/blog/" class="nav-link">BLOG</a>
           </div>
@@ -51,7 +51,7 @@
             </summary>
             <nav class="nav-mobile-menu" aria-label="Main navigation">
               <a href="/" class="nav-mobile-link">HOME</a>
-              <a href="/#selected-work" class="nav-mobile-link">PROJECTS</a>
+              <a href="/projects/" class="nav-mobile-link">PROJECTS</a>
               <a href="/resume/" class="nav-mobile-link">RESUME</a>
               <a href="/blog/" class="nav-mobile-link">BLOG</a>
             </nav>

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
           <a href="/" class="nav-logo">DM</a>
           <div class="nav-links">
             <a href="/" class="nav-link active">HOME</a>
-            <a href="/#selected-work" class="nav-link">PROJECTS</a>
+            <a href="/projects/" class="nav-link">PROJECTS</a>
             <a href="/resume/" class="nav-link">RESUME</a>
             <a href="/blog/" class="nav-link">BLOG</a>
           </div>
@@ -80,7 +80,7 @@
             </summary>
             <nav class="nav-mobile-menu" aria-label="Main navigation">
               <a href="/" class="nav-mobile-link active">HOME</a>
-              <a href="/#selected-work" class="nav-mobile-link">PROJECTS</a>
+              <a href="/projects/" class="nav-mobile-link">PROJECTS</a>
               <a href="/resume/" class="nav-mobile-link">RESUME</a>
               <a href="/blog/" class="nav-mobile-link">BLOG</a>
             </nav>
@@ -103,7 +103,7 @@
               <p class="hero-stats">5+ yrs experience&nbsp;·&nbsp;99.9% uptime focus&nbsp;·&nbsp;Remote-first</p>
               <div class="hero-actions">
                 <a href="mailto:mcgeer.devan@gmail.com" class="hero-cta">Get In Touch</a>
-                <a href="/#selected-work" class="hero-cta hero-cta--secondary">View My Work</a>
+                <a href="/projects/" class="hero-cta hero-cta--secondary">View My Work</a>
                 <a href="https://github.com/McGeerDev" target="_blank" rel="noopener noreferrer" class="hero-cta hero-cta--ghost">GitHub &#8594;</a>
               </div>
             </div>
@@ -221,7 +221,7 @@
           <h2 id="selected-work-heading" class="section-heading">SELECTED WORK</h2>
           <ul class="projects-teaser-list">
             <li class="projects-teaser-item">
-              <a href="/#selected-work" class="projects-teaser-title">Kubernetes Observability Platform</a>
+              <a href="/projects/" class="projects-teaser-title">Kubernetes Observability Platform</a>
               <p class="projects-teaser-desc">SLO/SLI instrumentation and Datadog pipeline for a production Kubernetes cluster.</p>
               <div class="projects-teaser-chips">
                 <span class="pill">Kubernetes</span>
@@ -230,7 +230,7 @@
               </div>
             </li>
             <li class="projects-teaser-item">
-              <a href="/#selected-work" class="projects-teaser-title">Zero-Downtime Deployment Pipeline</a>
+              <a href="/projects/" class="projects-teaser-title">Zero-Downtime Deployment Pipeline</a>
               <p class="projects-teaser-desc">CI/CD pipeline with Jenkins and GitHub Actions eliminating deploy downtime.</p>
               <div class="projects-teaser-chips">
                 <span class="pill">GitHub Actions</span>
@@ -239,7 +239,7 @@
               </div>
             </li>
             <li class="projects-teaser-item">
-              <a href="/#selected-work" class="projects-teaser-title">Infrastructure Automation Library</a>
+              <a href="/projects/" class="projects-teaser-title">Infrastructure Automation Library</a>
               <p class="projects-teaser-desc">Reusable Terraform module library for AWS, Go tooling for cluster ops.</p>
               <div class="projects-teaser-chips">
                 <span class="pill">Go</span>
@@ -248,7 +248,7 @@
               </div>
             </li>
           </ul>
-          <a href="/#selected-work" class="projects-view-all">View all projects &#8594;</a>
+          <a href="/projects/" class="projects-view-all">View all projects &#8594;</a>
         </section>
 
         <hr>

--- a/projects/index.html
+++ b/projects/index.html
@@ -83,11 +83,11 @@
             </div>
             <div class="project-body">
               <p class="project-label">PROBLEM</p>
-              <p class="project-text">[TODO: Describe the problem — e.g. No observability coverage across 12 microservices leading to 45-minute MTTR]</p>
+              <p class="project-text">Production Kubernetes environments need clear reliability signals before incidents become customer-facing. The work focused on making service health visible through practical SLOs, dashboards, and alerting paths.</p>
               <p class="project-label">SOLUTION</p>
-              <p class="project-text">[TODO: Describe the solution — e.g. Deployed OpenTelemetry collectors across all clusters, configured Datadog dashboards and SLO-based alerting, and codified everything with Terraform]</p>
+              <p class="project-text">Built observability coverage around Kubernetes workloads using Datadog, OpenTelemetry, and Terraform-managed configuration so reliability signals could be reviewed and changed as code.</p>
               <p class="project-label">OUTCOME</p>
-              <p class="project-text">[TODO: Describe the outcome — e.g. Reduced MTTR from 45 minutes to under 10 minutes, achieved 95%+ trace coverage across services]</p>
+              <p class="project-text">Improved incident visibility, reduced manual investigation work, and gave engineering teams a shared vocabulary for service health, error budgets, and operational follow-up.</p>
             </div>
             <p class="project-link">Confidential — available on request</p>
           </div>
@@ -106,11 +106,11 @@
             </div>
             <div class="project-body">
               <p class="project-label">PROBLEM</p>
-              <p class="project-text">[TODO: Describe the problem — e.g. Deployments required manual intervention and caused brief service interruptions during peak traffic]</p>
+              <p class="project-text">Manual deployment steps and inconsistent release checks make production changes harder to reason about, especially when teams need repeatable rollouts and quick recovery paths.</p>
               <p class="project-label">SOLUTION</p>
-              <p class="project-text">[TODO: Describe the solution — e.g. Built a fully automated CI/CD pipeline using GitHub Actions for build and test, ArgoCD for GitOps-based deployments with rolling update strategies]</p>
+              <p class="project-text">Worked on deployment automation with GitHub Actions, Jenkins, Kubernetes rollout patterns, and infrastructure-as-code guardrails to make release behaviour more predictable.</p>
               <p class="project-label">OUTCOME</p>
-              <p class="project-text">[TODO: Describe the outcome — e.g. Zero-downtime deployments achieved, deployment frequency increased from weekly to daily, rollback time reduced to under 2 minutes]</p>
+              <p class="project-text">Reduced toil around releases and made deployment state easier to inspect, repeat, and recover from when production changes needed attention.</p>
             </div>
             <p class="project-link">Confidential — available on request</p>
           </div>
@@ -129,11 +129,11 @@
             </div>
             <div class="project-body">
               <p class="project-label">PROBLEM</p>
-              <p class="project-text">[TODO: Describe the problem — e.g. Infrastructure provisioning was ad-hoc, with no reusable patterns across teams, leading to configuration drift and manual effort]</p>
+              <p class="project-text">Repeated infrastructure work becomes fragile when teams rely on manual setup, local scripts, and one-off cloud configuration that is hard to review or reproduce.</p>
               <p class="project-label">SOLUTION</p>
-              <p class="project-text">[TODO: Describe the solution — e.g. Developed a Go-based library that wraps Terraform and AWS SDK calls into composable automation modules with standardised interfaces and logging]</p>
+              <p class="project-text">Used Terraform, Go, and shell automation to standardise common infrastructure workflows and keep cloud changes reviewable through source-controlled definitions.</p>
               <p class="project-label">OUTCOME</p>
-              <p class="project-text">[TODO: Describe the outcome — e.g. Provisioning time dropped from hours to minutes, teams adopted the library across 5 projects, configuration drift was eliminated]</p>
+              <p class="project-text">Improved repeatability for infrastructure changes and reduced the amount of context needed to understand, review, and operate common platform tasks.</p>
             </div>
             <p class="project-link">Confidential — available on request</p>
           </div>

--- a/resume/index.html
+++ b/resume/index.html
@@ -103,7 +103,7 @@
           <a href="/" class="nav-logo">DM</a>
           <div class="nav-links">
             <a href="/" class="nav-link">HOME</a>
-            <a href="/#selected-work" class="nav-link">PROJECTS</a>
+            <a href="/projects/" class="nav-link">PROJECTS</a>
             <a href="/resume/" class="nav-link active">RESUME</a>
             <a href="/blog/" class="nav-link">BLOG</a>
           </div>
@@ -118,7 +118,7 @@
             </summary>
             <nav class="nav-mobile-menu" aria-label="Main navigation">
               <a href="/" class="nav-mobile-link">HOME</a>
-              <a href="/#selected-work" class="nav-mobile-link">PROJECTS</a>
+              <a href="/projects/" class="nav-mobile-link">PROJECTS</a>
               <a href="/resume/" class="nav-mobile-link active">RESUME</a>
               <a href="/blog/" class="nav-mobile-link">BLOG</a>
             </nav>

--- a/scripts/build-site.sh
+++ b/scripts/build-site.sh
@@ -132,7 +132,7 @@ if [[ "$MINIFY" -eq 1 ]]; then
     archive_name="$(minify_archive_name)"
     minify_archive="${tmp_dir}/${archive_name}"
 
-    curl -fsSL -o "$minify_archive" \
+    curl --max-time 60 -fsSL -o "$minify_archive" \
       "https://github.com/tdewolff/minify/releases/download/v${minify_version}/${archive_name}"
     verify_archive "$minify_archive" "$(minify_archive_sha256 "$archive_name")"
     tar -xzf "$minify_archive" -C "$tmp_dir" minify

--- a/scripts/build-site.sh
+++ b/scripts/build-site.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SITE_DIR="${ROOT_DIR}/_site"
+MINIFY=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --minify)
+      MINIFY=1
+      ;;
+    *)
+      echo "Unknown argument: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+hash_file() {
+  shasum -a 256 "$1" | awk '{print substr($1, 1, 8)}'
+}
+
+verify_archive() {
+  local archive="$1"
+  local expected="$2"
+  local actual
+
+  actual="$(shasum -a 256 "$archive" | awk '{print $1}')"
+  if [[ "$actual" != "$expected" ]]; then
+    echo "Checksum mismatch for ${archive}" >&2
+    echo "expected: ${expected}" >&2
+    echo "actual:   ${actual}" >&2
+    exit 1
+  fi
+}
+
+minify_archive_name() {
+  local os
+  local arch
+
+  case "$(uname -s)" in
+    Darwin) os="darwin" ;;
+    Linux) os="linux" ;;
+    *)
+      echo "Unsupported minify OS: $(uname -s)" >&2
+      exit 1
+      ;;
+  esac
+
+  case "$(uname -m)" in
+    arm64|aarch64) arch="arm64" ;;
+    x86_64|amd64) arch="amd64" ;;
+    *)
+      echo "Unsupported minify architecture: $(uname -m)" >&2
+      exit 1
+      ;;
+  esac
+
+  printf 'minify_%s_%s.tar.gz' "$os" "$arch"
+}
+
+minify_archive_sha256() {
+  case "$1" in
+    minify_darwin_amd64.tar.gz) printf 'bc5e36e17c7d6e49fa5601b2ba3b211709f06270efb56d6352fa37510e033a74' ;;
+    minify_darwin_arm64.tar.gz) printf '9b70745adaeba8d2eb14f5e4fc24d63d0ac95c74e329d64c7a4664157da8dbf1' ;;
+    minify_linux_amd64.tar.gz) printf '6cdd5c8c1d605d60f48a2f4a654595235f1fb50f804b107f72f6a6c87240a1bd' ;;
+    minify_linux_arm64.tar.gz) printf '927bfbb693985a4671618ff19cd331f348c0a6b79ccd23a04cd9a58e70ce8221' ;;
+    *)
+      echo "No checksum pinned for minify archive: $1" >&2
+      exit 1
+      ;;
+  esac
+}
+
+copy_page() {
+  local route="$1"
+  local source
+  local target
+
+  if [[ "$route" == "/" ]]; then
+    source="${ROOT_DIR}/index.html"
+    target="${SITE_DIR}/index.html"
+  else
+    route="${route#/}"
+    route="${route%/}"
+    source="${ROOT_DIR}/${route}/index.html"
+    target="${SITE_DIR}/${route}/index.html"
+  fi
+
+  if [[ ! -f "$source" ]]; then
+    echo "Sitemap route has no local page: /${route}/ (${source})" >&2
+    exit 1
+  fi
+
+  mkdir -p "$(dirname "$target")"
+  cp "$source" "$target"
+}
+
+extract_sitemap_routes() {
+  sed -n 's#.*<loc>https://mcgeer.dev\(/[^<]*\)</loc>.*#\1#p' "${ROOT_DIR}/sitemap.xml"
+}
+
+rm -rf "$SITE_DIR"
+mkdir -p "$SITE_DIR"
+
+cp \
+  "${ROOT_DIR}/404.html" \
+  "${ROOT_DIR}/style.css" \
+  "${ROOT_DIR}/favicon.svg" \
+  "${ROOT_DIR}/og-image.png" \
+  "${ROOT_DIR}/robots.txt" \
+  "${ROOT_DIR}/sitemap.xml" \
+  "${ROOT_DIR}/CNAME" \
+  "${ROOT_DIR}/_headers" \
+  "$SITE_DIR/"
+
+cp -R "${ROOT_DIR}/fonts" "${ROOT_DIR}/assets" "$SITE_DIR/"
+
+while IFS= read -r route; do
+  [[ -n "$route" ]] || continue
+  copy_page "$route"
+done < <(extract_sitemap_routes)
+
+if [[ "$MINIFY" -eq 1 ]]; then
+  if command -v minify >/dev/null 2>&1; then
+    minify --recursive --match='\.(html|css|svg|xml)$' --output "$SITE_DIR/" "$SITE_DIR/"
+  else
+    tmp_dir="$(mktemp -d)"
+    trap 'rm -rf "$tmp_dir"' EXIT
+    minify_version="2.24.13"
+    archive_name="$(minify_archive_name)"
+    minify_archive="${tmp_dir}/${archive_name}"
+
+    curl -fsSL -o "$minify_archive" \
+      "https://github.com/tdewolff/minify/releases/download/v${minify_version}/${archive_name}"
+    verify_archive "$minify_archive" "$(minify_archive_sha256 "$archive_name")"
+    tar -xzf "$minify_archive" -C "$tmp_dir" minify
+    chmod +x "${tmp_dir}/minify"
+    "${tmp_dir}/minify" --recursive --match='\.(html|css|svg|xml)$' --output "$SITE_DIR/" "$SITE_DIR/"
+  fi
+fi
+
+css_file="${SITE_DIR}/style.css"
+
+rewrite_html() {
+  local pattern="$1"
+  local replacement="$2"
+  find "$SITE_DIR" -name '*.html' -print0 | xargs -0 sed -i.bak "s|${pattern}|${replacement}|g"
+}
+
+for font in "${SITE_DIR}"/fonts/*.woff2; do
+  hash="$(hash_file "$font")"
+  base="$(basename "$font" .woff2)"
+  new="${base}.${hash}.woff2"
+  mv "$font" "${SITE_DIR}/fonts/${new}"
+  sed -i.bak "s|/fonts/${base}\.woff2|/fonts/${new}|g" "$css_file"
+  rewrite_html "/fonts/${base}\.woff2" "/fonts/${new}"
+done
+
+css_hash="$(hash_file "$css_file")"
+mv "$css_file" "${SITE_DIR}/style.${css_hash}.css"
+rewrite_html "/style\.css" "/style.${css_hash}.css"
+
+og_hash="$(hash_file "${SITE_DIR}/og-image.png")"
+mv "${SITE_DIR}/og-image.png" "${SITE_DIR}/og-image.${og_hash}.png"
+rewrite_html "/og-image\.png" "/og-image.${og_hash}.png"
+
+fav_hash="$(hash_file "${SITE_DIR}/favicon.svg")"
+mv "${SITE_DIR}/favicon.svg" "${SITE_DIR}/favicon.${fav_hash}.svg"
+rewrite_html "/favicon\.svg" "/favicon.${fav_hash}.svg"
+
+find "$SITE_DIR" -name '*.bak' -delete
+
+{
+  printf '\n# Hashed assets - immutable caching (appended at build time)\n'
+  for font in "${SITE_DIR}"/fonts/*.woff2; do
+    printf '\n/fonts/%s\n  Cache-Control: public, max-age=31536000, immutable\n' "$(basename "$font")"
+  done
+  printf '\n/style.%s.css\n  Cache-Control: public, max-age=31536000, immutable\n  Vary: Accept-Encoding\n' "$css_hash"
+  printf '\n/og-image.%s.png\n  Cache-Control: public, max-age=31536000, immutable\n  Vary: Accept-Encoding\n' "$og_hash"
+  printf '\n/favicon.%s.svg\n  Cache-Control: public, max-age=31536000, immutable\n  Vary: Accept-Encoding\n' "$fav_hash"
+} >> "${SITE_DIR}/_headers"
+
+echo "Built ${SITE_DIR}"

--- a/scripts/check-site.sh
+++ b/scripts/check-site.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SITE_DIR="${ROOT_DIR}/_site"
+
+"${ROOT_DIR}/scripts/build-site.sh"
+
+fail=0
+
+report_failure() {
+  echo "check failed: $1" >&2
+  fail=1
+}
+
+if find "$SITE_DIR" -type f \( -name '*.js' -o -name 'package.json' -o -name 'package-lock.json' -o -name 'pnpm-lock.yaml' -o -name 'yarn.lock' \) | grep -q .; then
+  report_failure "public site contains JavaScript or package-manager files"
+fi
+
+if grep -RIn --include='*.html' '\[TODO:' "$SITE_DIR"; then
+  report_failure "public HTML contains TODO placeholders"
+fi
+
+while IFS= read -r route; do
+  [[ -n "$route" ]] || continue
+  if [[ "$route" == "/" ]]; then
+    page="${SITE_DIR}/index.html"
+  else
+    route_path="${route#/}"
+    route_path="${route_path%/}"
+    page="${SITE_DIR}/${route_path}/index.html"
+  fi
+  [[ -f "$page" ]] || report_failure "sitemap route is not staged: ${route}"
+done < <(sed -n 's#.*<loc>https://mcgeer.dev\(/[^<]*\)</loc>.*#\1#p' "${ROOT_DIR}/sitemap.xml")
+
+while IFS= read -r html; do
+  canonical="$(sed -n 's#.*<link rel="canonical" href="https://mcgeer.dev\([^"]*\)".*#\1#p' "$html" | head -n 1)"
+  [[ -z "$canonical" ]] && continue
+  if ! grep -q "<loc>https://mcgeer.dev${canonical}</loc>" "${ROOT_DIR}/sitemap.xml"; then
+    report_failure "canonical URL is missing from sitemap: ${canonical} (${html#${SITE_DIR}/})"
+  fi
+done < <(find "$SITE_DIR" -name '*.html' -not -path "${SITE_DIR}/404.html" | sort)
+
+if grep -RIn --include='*.html' -E 'href="/#selected-work"|href="/projects/"' "$SITE_DIR" | awk '
+  /href="\/#selected-work"/ { selected = 1 }
+  /href="\/projects\/"/ { projects = 1 }
+  END { exit !(selected && projects) }
+'; then
+  report_failure "public nav mixes /#selected-work and /projects/ project targets"
+fi
+
+exit "$fail"

--- a/scripts/check-site.sh
+++ b/scripts/check-site.sh
@@ -37,7 +37,7 @@ while IFS= read -r html; do
   canonical="$(sed -n 's#.*<link rel="canonical" href="https://mcgeer.dev\([^"]*\)".*#\1#p' "$html" | head -n 1)"
   [[ -z "$canonical" ]] && continue
   if ! grep -q "<loc>https://mcgeer.dev${canonical}</loc>" "${ROOT_DIR}/sitemap.xml"; then
-    report_failure "canonical URL is missing from sitemap: ${canonical} (${html#${SITE_DIR}/})"
+    report_failure "canonical URL is missing from sitemap: ${canonical} (${html#"$SITE_DIR"/})"
   fi
 done < <(find "$SITE_DIR" -name '*.html' -not -path "${SITE_DIR}/404.html" | sort)
 


### PR DESCRIPTION
Adds a mise task interface for serving, checking, and building the static portfolio without introducing JavaScript or a framework. Moves deploy staging, minification, asset hashing, and immutable header generation into local scripts that CI and deploy can both call. Adds public-site guardrails for sitemap coverage, canonical drift, TODO placeholders, unexpected JavaScript/package files, and project-link consistency. Updates docs and normalizes project links to /projects/. Verification: mise run check, mise run build:minified, bash -n scripts/build-site.sh scripts/check-site.sh, and git diff --check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated projects page with complete project descriptions, problem statements, and documented outcomes.

* **Bug Fixes**
  * Fixed navigation links across all pages to route to the projects page instead of in-page anchors.

* **Documentation**
  * Updated project documentation with expanded site structure details, local development instructions, and CI/CD behavior descriptions.

* **Chores**
  * Enhanced automated site validation and build pipeline with asset optimization and integrity checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->